### PR TITLE
secret.conf: channel must start with '#' or '&'

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -133,6 +133,14 @@ int main(int argc, char **argv)
                 } else if (sv_eq(key, SV("password"))) {
                     secret_password = value;
                 } else if (sv_eq(key, SV("channel"))) {
+                    switch(value.data[0]) {
+                    case '#':
+                    case '&':
+                        break;
+                    default:
+                        log_error(&log, "`channel` must start with a '#' or '&' character");
+                        goto error;
+                    }
                     secret_channel = value;
                 } else {
                     log_error(&log, "unknown key `"SV_Fmt"`", SV_Arg(key));


### PR DESCRIPTION
Khello. When setting up kgbotka I forgot to put '#' before the channel name.
The output seemed fine, it took me some time to debug, so i thought it would be nice to have this kind of check.

https://tools.ietf.org/html/rfc1459#section-1.3