### PR TITLE
twitch tags & fix irc_pong

### DIFF
--- a/src/irc.c
+++ b/src/irc.c
@@ -223,9 +223,10 @@ void irc_pong(Irc *irc, String_View response)
     irc_write_cstr(irc, "\n");
 }
 
-void irc_tags(Irc *irc, String_View request)
+void irc_cap_req(Irc *irc, String_View capabilities)
 {
-    irc_write_sv(irc, request);
+    irc_write_cstr(irc, "CAP REQ :");
+    irc_write_sv(irc, capabilities);
     irc_write_cstr(irc, "\n");
 }
 

--- a/src/irc.c
+++ b/src/irc.c
@@ -222,6 +222,12 @@ void irc_pong(Irc *irc, String_View response)
     irc_write_sv(irc, response);
 }
 
+void irc_tags(Irc *irc, String_View request)
+{
+    irc_write_sv(irc, request);
+    irc_write_cstr(irc, "\n");
+}
+
 bool params_next(String_View *params, String_View *output)
 {
     assert(params);

--- a/src/irc.c
+++ b/src/irc.c
@@ -220,6 +220,7 @@ void irc_pong(Irc *irc, String_View response)
 {
     irc_write_cstr(irc, "PONG :");
     irc_write_sv(irc, response);
+    irc_write_cstr(irc, "\n");
 }
 
 void irc_tags(Irc *irc, String_View request)

--- a/src/irc.h
+++ b/src/irc.h
@@ -30,6 +30,7 @@ void irc_join(Irc *irc, String_View channel);
 void irc_nick(Irc *irc, String_View nickname);
 void irc_privmsg(Irc *irc, String_View channel, String_View message);
 void irc_pong(Irc *irc, String_View response);
+void irc_tags(Irc *irc, String_View request);
 
 bool params_next(String_View *params, String_View *output);
 

--- a/src/irc.h
+++ b/src/irc.h
@@ -30,7 +30,7 @@ void irc_join(Irc *irc, String_View channel);
 void irc_nick(Irc *irc, String_View nickname);
 void irc_privmsg(Irc *irc, String_View channel, String_View message);
 void irc_pong(Irc *irc, String_View response);
-void irc_tags(Irc *irc, String_View request);
+void irc_cap_req(Irc *irc, String_View capabilities);
 
 bool params_next(String_View *params, String_View *output);
 

--- a/src/main.c
+++ b/src/main.c
@@ -238,9 +238,9 @@ int main(int argc, char **argv)
 
         log_info(&log, "Connected to Twitch IRC successfully");
 
-        // TODO: no support for Twitch IRC tags
         irc_pass(&irc, secret_password);
         irc_nick(&irc, secret_nickname);
+        irc_tags(&irc, SV("CAP REQ :twitch.tv/tags"));
         irc_join(&irc, secret_channel);
     }
 
@@ -275,6 +275,10 @@ int main(int argc, char **argv)
 
                         // Process the IRC messsage
                         {
+                            if (sv_starts_with(line, SV("@"))) {
+                                String_View tags = sv_chop_by_delim(&line, ' ');
+                                (void) tags;
+                            }
                             if (sv_starts_with(line, SV(":"))) {
                                 String_View prefix = sv_chop_by_delim(&line, ' ');
                                 (void) prefix;

--- a/src/main.c
+++ b/src/main.c
@@ -240,7 +240,7 @@ int main(int argc, char **argv)
 
         irc_pass(&irc, secret_password);
         irc_nick(&irc, secret_nickname);
-        irc_tags(&irc, SV("CAP REQ :twitch.tv/tags"));
+        irc_cap_req(&irc, SV("twitch.tv/tags"));
         irc_join(&irc, secret_channel);
     }
 


### PR DESCRIPTION
![tsodinFlushed](https://cdn.betterttv.net/emote/603a96807c74605395f35736/1x) /

`irc_pong` doesn't send `\n`, causing the next issued command to be ignored