### PR TITLE
handle ssl errors

### DIFF
--- a/src/irc.c
+++ b/src/irc.c
@@ -132,11 +132,20 @@ bool irc_connect_secure(Log *log, Irc *irc, SSL_CTX *ctx,
 
     // Upgrade to SSL connection
     {
-        // TODO: SSL_new() can fail
         irc->ssl = SSL_new(ctx);
+        if(!irc->ssl) {
+            char buf[512] = {0};
+            ERR_error_string_n(ERR_get_error(), buf, sizeof(buf));
+            log_error(log, "Could not create a SSL structure: %s", buf);
+            goto error;
+        }
 
-        // TODO: SSL_set_fd() can fail
-        SSL_set_fd(irc->ssl, irc->sd);
+        if (!SSL_set_fd(irc->ssl, irc->sd)) {
+            char buf[512] = {0};
+            ERR_error_string_n(ERR_get_error(), buf, sizeof(buf));
+            log_error(log, "Could not set the SSL file descriptor: %s", buf);
+            goto error;
+        }
 
         int ret = SSL_connect(irc->ssl);
         if (ret < 0) {

--- a/src/main.c
+++ b/src/main.c
@@ -206,9 +206,9 @@ int main(int argc, char **argv)
         ctx = SSL_CTX_new(TLS_client_method());
 
         if (ctx == NULL) {
-            // TODO: SSL_CTX_new error is not located in errno
-            log_error(&log, "Could not initialize the SSL context: %s",
-                      strerror(errno));
+            char buf[512] = {0};
+            ERR_error_string_n(ERR_get_error(), buf, sizeof(buf));
+            log_error(&log, "Could not initialize the SSL context: %s", buf);
             goto error;
         }
 


### PR DESCRIPTION
After a small research, I'm still not sure if this will print the correct ssl error.
But at least it makes sure that `SSL_new` and `SSL_set_fd` went successful.

https://www.openssl.org/docs/manmaster/man3/ERR_get_error.html