### PR TITLE
added msys2 sh and ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 # like https://github.com/msys2/MINGW-packages/blob/master/.github/workflows/main.yml#L35
       - name: Move Checkout
         run: |
-          Copy-Item -Path ".\temp" -Destination "C:\_" -Recurse
+          Copy-Item -Path "." -Destination "C:\_" -Recurse
       - name: Build
         run: |
           cd /C/_

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,40 @@ jobs:
           CC: clang
           CXX: clang++
           PKG_CONFIG_PATH: /usr/local/opt/openssl/lib/pkgconfig
-# TODO(#21): no CI for windows
+  build-windows-mingw-inside_msys2_shell:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: [
+          { msystem: MINGW64, msystem_lower: mingw64, arch: x86_64 }
+          ,{msystem: MINGW32, msystem_lower: mingw32, arch: i686   }
+        ]          
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          path: temp
+          fetch-depth: 0
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          install: mingw-w64-${{ matrix.arch }}-toolchain mingw-w64-${{ matrix.arch }}-pkg-config mingw-w64-${{ matrix.arch }}-brotli mingw-w64-${{ matrix.arch }}-curl
+          update: true
+      - name: Update and Install mingw and packages
+        run: |
+          msys2 -c 'pacman --noconfirm -Suuy'
+          msys2 -c 'pacman --noconfirm -Suu'
+# like https://github.com/msys2/MINGW-packages/blob/master/.github/workflows/main.yml#L35
+      - name: Move Checkout
+        run: |
+          Copy-Item -Path ".\temp" -Destination "C:\_" -Recurse
+      - name: Build
+        run: |
+          cd /C/_
+          MINGW_ARCH=${{ matrix.msystem }} ./build_msys2.sh
+        shell: msys2 {0}
+        env:
+          CC: gcc
+          CXX: g++
+# TODO(#21): no CI for windows::msvc
 # TODO(#25): no CI for freebsd

--- a/build_msys2.sh
+++ b/build_msys2.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -xe
+
+CFLAGS="-Wall -Wextra -std=c11 -pedantic -ggdb"
+SSL_CFLAGS=`pkg-config --cflags openssl --static`
+SSL_LIBS=`pkg-config --libs openssl --static`
+# static curl linking have problem 2020: https://github.com/msys2/MINGW-packages/issues/6769
+CURL_CFLAGS=`pkg-config --cflags libcurl --static`
+CURL_LIBS=`pkg-config --libs libcurl`
+
+cc $CFLAGS $SSL_CFLAGS $CURL_CFLAGS -o kgbotka src/main.c src/sv.c src/log.c src/irc.c src/cmd.c src/region.c -lm $SSL_LIBS $CURL_LIBS -lpthread


### PR DESCRIPTION
Added msys2::mingw build by using `build_msys2.sh` and msys2 posix-like environment (out of the box).
Windows-native methods of `build_msys2.bat` are not used here.
Compilation done OK.
It's only non-static executable generated cuz probably "the MSYS2 **_static_** LibCurl is broken."(https://github.com/msys2/MINGW-packages/issues/3538) but i am not sure.